### PR TITLE
Replace Ubuntu with Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
-FROM ubuntu:17.04
+FROM alpine
 
-RUN apt-get update && \
-    apt-get install -y qemu && \
-    rm -rf /var/lib/apt/lists/*
+RUN apk add qemu-system-i386 qemu-ui-curses
 
 WORKDIR /app
 ADD app .

--- a/app/entrypoint.sh
+++ b/app/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 
 ## Establish default command flags or override with Environment variables
-OPTS=${OPTS:-"-fda floppy.img -boot a -curses"}
+OPTS=${OPTS:-"-boot a -display curses -drive format=raw,if=floppy,readonly=off,file=floppy.img,index=0"}
 
 ## If Command has value expand defaults
 [[ $# -gt 0 ]] && OPTS += "$*"


### PR DESCRIPTION
Ubuntu is too heavy. Let's use Alpine instead.
Alpine is a lightweight Linux distro whose virtual image size is only 5 MB.

https://hub.docker.com/_/alpine